### PR TITLE
kill child engine processes when dead engine detected

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -122,7 +122,7 @@ Engine engine_new(str_t cmd, str_t name, str_t uciOptions, FILE *log, Deadline *
     vec_del_rec(args, str_del);
 
     // Start the uci..uciok dialogue
-    deadline_set(deadline, &e, system_msec() + 1000);
+    deadline_set(deadline, &e, system_msec() + 2000);
     engine_writeln(&e, "uci");
     scope(str_del) str_t line = {0};
 


### PR DESCRIPTION
Slow systems under heavy load that use EvalFile NNUE engine loads may not be able to respond back by the deadline.  If these engines are then labeled as dead, the child engine processes are leaked on the system and not properly closed.

This patch makes the uci command response more forgiving before the deadline, while also properly killing the child engine processes before exiting.

Please note that this introduces a compiler warning, so you may want to tweak this some yourself.  The problem is the main thread must use the Workers.deadline object to access the engines to close them.  Unfortunately all the Engine pointers are const in the codebase, and we cannot use a const pointer here since we are freeing the engine name from the engine pointer.  Aside from removing 'const' from every Engine * in the codebase, I do not see an easy fix here.  For now the compiler warning could be ignored until a better solution is in place.