### PR TITLE
Flush pgn file

### DIFF
--- a/src/seqwriter.c
+++ b/src/seqwriter.c
@@ -76,6 +76,7 @@ void seq_writer_push(SeqWriter *sw, size_t idx, str_t str)
             fputs(sw->buf[j].str.buf, sw->out);
             seq_str_destroy(&sw->buf[j]);
         }
+        fflush(sw->out);
 
         // Delete buf[0..i-1]
         memmove(&sw->buf[0], &sw->buf[i], (vec_size(sw->buf) - i) * sizeof(SeqStr));


### PR DESCRIPTION
flush file content after writing a bunch of output.

Makes it less likely a pgn file inspected during a running tournament is incomplete.