### PR TITLE
Increase isready timeout

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -212,7 +212,7 @@ void engine_writeln(const Worker *w, const Engine *e, char *buf)
 
 void engine_sync(Worker *w, const Engine *e)
 {
-    deadline_set(w, e->name.buf, system_msec() + 1000);
+    deadline_set(w, e->name.buf, system_msec() + 2000);
     engine_writeln(w, e, "isready");
     scope(str_destroy) str_t line = str_init();
 


### PR DESCRIPTION
When running on slow hardware such as a raspberry pi and using an engine that loads a NNUE binary as part of a setoption, the engine can timeout.  This was tested on a raspberry pi loading NNUE binaries in Minic.  Doubling the value resolves the issue for this use case.