### PR TITLE
Validate concurrency

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -249,9 +249,11 @@ EngineOptions *options_parse(int argc, const char **argv, Options *o) {
             o->gauntlet = true;
         else if (!strcmp(argv[i], "-log"))
             o->log = true;
-        else if (!strcmp(argv[i], "-concurrency"))
+        else if (!strcmp(argv[i], "-concurrency")) {
             o->concurrency = atoi(argv[++i]);
-        else if (!strcmp(argv[i], "-each")) {
+            if (o->concurrency < 1)
+                DIE("Invalid value for -concurrency: '%s'\n", argv[i]);
+        } else if (!strcmp(argv[i], "-each")) {
             i = options_parse_eo(argc, argv, i + 1, &each);
             eachSet = true;
         } else if (!strcmp(argv[i], "-engine")) {


### PR DESCRIPTION
If concurrency isn't a positive integer, c-chess-cli hangs forever in the main thread loop.

This can be tested with:

```
./c-chess-cli -engine cmd=stockfish -engine cmd=stockfish -each tc=1+0 -games 1 -concurrency 'a'
```